### PR TITLE
Add docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py app.py
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ npm install lucide-react
 # Replace src/App.js with the React code
 npm start
 ```
+
+## Running with Docker Compose
+
+This repository also provides a `docker-compose.yml` file that spins up the
+Flask backend and a development server for the React frontend. The compose
+setup expects that you have created the React application inside a
+`virtualvinyl/` directory as shown in the steps above.
+
+Start both services with:
+
+```bash
+docker-compose up
+```
+
+The backend will be available on <http://localhost:5000> and the frontend on
+<http://localhost:3000>.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  backend:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/app
+    environment:
+      - FLASK_ENV=development
+  frontend:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./virtualvinyl:/app
+    command: sh -c "npm install && npm start"
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Summary
- provide a Dockerfile for the Flask backend
- add a `docker-compose.yml` example to run backend and frontend
- document how to start the services in README

## Testing
- `python -m py_compile app.py`
- ❌ `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498ae44bac8328890720e4a4ddce71