### PR TITLE
Add docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py app.py
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+RUN npx create-react-app . --template typescript
+RUN npm install lucide-react
+COPY react_frontend.tsx src/App.tsx
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ npm install lucide-react
 # Replace src/App.js with the React code
 npm start
 ```
+
+## Running with Docker Compose
+
+This repository also provides a `docker-compose.yml` file that spins up the
+Flask backend and builds a React frontend automatically. The compose setup
+installs Python dependencies, generates a TypeScript React application, copies
+`react_frontend.tsx` into it and starts both development servers. No manual
+setup steps are required.
+
+Start both services with (use `--build` the first time to build the images):
+
+```bash
+docker-compose up
+```
+
+The backend will be available on <http://localhost:5000> and the frontend on
+<http://localhost:3000>.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  backend:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/app
+    environment:
+      - FLASK_ENV=development
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Summary
- provide a Dockerfile for the Flask backend
- add a `docker-compose.yml` example to run backend and frontend
- document how to start the services in README
- create a Dockerfile.frontend to automatically build the React app
- update compose configuration to build frontend image
- mention auto-build in README

## Testing
- `python -m py_compile app.py`
- ❌ `docker-compose --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498ae44bac8328890720e4a4ddce71