### PR TITLE
Fix duration rounding

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ from flask_cors import CORS
 import requests
 import base64
 import secrets
-import os
 from urllib.parse import urlencode
 
 app = Flask(__name__)

--- a/react_frontend.tsx
+++ b/react_frontend.tsx
@@ -144,8 +144,8 @@ const VirtualVinyl = () => {
 
   const formatDuration = (ms) => {
     const minutes = Math.floor(ms / 60000);
-    const seconds = ((ms % 60000) / 1000).toFixed(0);
-    return `${minutes}:${seconds.padStart(2, '0')}`;
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
   };
 
   if (!isAuthenticated) {


### PR DESCRIPTION
## Summary
- prevent second rounding errors when formatting durations in the React frontend
- clean up unused import in the Flask app

## Testing
- `python -m py_compile app.py`
- `python -m pyflakes app.py`
- `python -m flake8 app.py | head`
- `npx tsc --noEmit react_frontend.tsx` *(fails: Cannot find global value 'Promise')*

------
https://chatgpt.com/codex/tasks/task_b_68499788f36883289e253793c7d46495