### PR TITLE
Fix TS errors in frontend

### DIFF
--- a/virtual-vinyl-frontend/src/App.tsx
+++ b/virtual-vinyl-frontend/src/App.tsx
@@ -13,9 +13,13 @@ interface Track {
   artists: { name: string }[];
 }
 
+interface SpotifyUser {
+  display_name: string;
+}
+
 const VirtualVinyl = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<SpotifyUser | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Track[]>([]);
   const [vinylTracks, setVinylTracks] = useState<Track[]>([]);


### PR DESCRIPTION
## Summary
- add `SpotifyUser` interface
- type `user` with `SpotifyUser | null`

## Testing
- `pip install -U pip`
- `pip install -r requirements.txt`
- `python app.py` *(fails to run due to server blocking; closed after startup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6849b59a39c0832886d35f3d61a21160