### PR TITLE
Refactor backend for AWS Lambda

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 [x] Use Githubs Pages to display the static website. Transform Dash frontend into HTML/js if necessary
 [ ] Check [website](https://cperales.github.io/virtualvinyl) is active.
 [x] Convert the backend into an AWS Lambda function
+[x] Remove the Flask dependency from the backend
 
 
 # Bugs

--- a/app.py
+++ b/app.py
@@ -1,199 +1,239 @@
 # app.py
-from flask import Flask, request, jsonify, redirect, session
-from flask_cors import CORS
-import requests
+"""AWS Lambda backend for VirtualVinyl without Flask."""
 import base64
+import json
+import os
 import secrets
 from urllib.parse import urlencode
+
 import dotenv
-import os
-import awsgi
+import requests
 
 # Load environment variables from .env file
 dotenv.load_dotenv()
 
-app = Flask(__name__)
-app.secret_key = 'your-secret-key-here'  # Change this in production
-CORS(app, supports_credentials=True)
-
 # Spotify App Credentials (replace with your actual credentials)
-CLIENT_ID = os.getenv('SPOTIFY_CLIENT_ID')
-CLIENT_SECRET = os.getenv('SPOTIFY_CLIENT_SECRET')
-REDIRECT_URI = 'https://cperales.github.io/VirtualVinyl/callback'  # Change to your actual redirect URI
+CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
+CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
+REDIRECT_URI = "https://cperales.github.io/VirtualVinyl/callback"
 
-SPOTIFY_AUTH_URL = 'https://accounts.spotify.com/authorize'
-SPOTIFY_TOKEN_URL = 'https://accounts.spotify.com/api/token'
-SPOTIFY_API_BASE_URL = 'https://api.spotify.com/v1'
+SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
+SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
+SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
+
+# In-memory session store for lambda usage
+SESSION_STORE = {}
 
 
-def get_auth_header():
-    """Get authorization header for Spotify API calls"""
-    if 'access_token' in session:
-        return {'Authorization': f'Bearer {session["access_token"]}'}
+def _parse_cookies(header):
+    """Parse cookie header into a dictionary."""
+    cookies = {}
+    if not header:
+        return cookies
+    for item in header.split(";"):
+        if "=" in item:
+            k, v = item.split("=", 1)
+            cookies[k.strip()] = v
+    return cookies
+
+
+def _get_session(event):
+    """Retrieve session dict based on session_id cookie."""
+    headers = event.get("headers") or {}
+    cookie_header = headers.get("cookie") or headers.get("Cookie")
+    cookies = _parse_cookies(cookie_header)
+    session_id = cookies.get("session_id")
+    if session_id and session_id in SESSION_STORE:
+        return session_id, SESSION_STORE[session_id]
+    return None, None
+
+
+def _create_response(body="", status=200, headers=None):
+    """Create a standard lambda proxy response."""
+    if headers is None:
+        headers = {}
+    if isinstance(body, (dict, list)):
+        body = json.dumps(body)
+        headers.setdefault("Content-Type", "application/json")
+    return {"statusCode": status, "headers": headers, "body": body}
+
+
+def get_auth_header(session):
+    """Get authorization header for Spotify API calls."""
+    if session and "access_token" in session:
+        return {"Authorization": f"Bearer {session['access_token']}"}
     return None
 
 
-@app.route('/login')
-def login():
-    """Initiate Spotify OAuth flow"""
+def login(event):
+    """Initiate Spotify OAuth flow."""
     state = secrets.token_urlsafe(16)
-    session['state'] = state
+    session_id = secrets.token_urlsafe(16)
+    SESSION_STORE[session_id] = {"state": state}
 
     params = {
-        'client_id': CLIENT_ID,
-        'response_type': 'code',
-        'redirect_uri': REDIRECT_URI,
-        'state': state,
-        'scope': (
-            'user-read-private user-read-email playlist-modify-public '
-            'playlist-modify-private user-library-read'
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "state": state,
+        "scope": (
+            "user-read-private user-read-email playlist-modify-public "
+            "playlist-modify-private user-library-read"
         ),
     }
-
     auth_url = f"{SPOTIFY_AUTH_URL}?{urlencode(params)}"
-    return redirect(auth_url)
+    headers = {
+        "Location": auth_url,
+        "Set-Cookie": f"session_id={session_id}; Path=/; HttpOnly",
+    }
+    return _create_response(status=302, headers=headers)
 
 
-@app.route('/callback')
-def callback():
-    """Handle Spotify OAuth callback"""
-    code = request.args.get('code')
-    state = request.args.get('state')
+def callback(event):
+    """Handle Spotify OAuth callback."""
+    params = event.get("queryStringParameters") or {}
+    code = params.get("code")
+    state = params.get("state")
 
-    if not code or state != session.get('state'):
-        return jsonify({'error': 'Invalid callback'}), 400
+    session_id, session = _get_session(event)
+    if not code or not session or state != session.get("state"):
+        return _create_response({"error": "Invalid callback"}, 400)
 
-    # Exchange code for access token
     auth_str = f"{CLIENT_ID}:{CLIENT_SECRET}"
-    auth_bytes = auth_str.encode('ascii')
-    auth_b64 = base64.b64encode(auth_bytes).decode('ascii')
+    auth_b64 = base64.b64encode(auth_str.encode("ascii")).decode("ascii")
 
     headers = {
-        'Authorization': f'Basic {auth_b64}',
-        'Content-Type': 'application/x-www-form-urlencoded',
+        "Authorization": f"Basic {auth_b64}",
+        "Content-Type": "application/x-www-form-urlencoded",
     }
-
-    data = {
-        'grant_type': 'authorization_code',
-        'code': code,
-        'redirect_uri': REDIRECT_URI,
-    }
-
+    data = {"grant_type": "authorization_code", "code": code, "redirect_uri": REDIRECT_URI}
     response = requests.post(SPOTIFY_TOKEN_URL, headers=headers, data=data)
     token_data = response.json()
 
-    if 'access_token' in token_data:
-        session['access_token'] = token_data['access_token']
-        session['refresh_token'] = token_data.get('refresh_token')
-        return redirect('http://localhost:3000?auth=success')
+    if "access_token" in token_data:
+        session["access_token"] = token_data["access_token"]
+        session["refresh_token"] = token_data.get("refresh_token")
+        headers = {
+            "Location": "http://localhost:3000?auth=success",
+            "Set-Cookie": f"session_id={session_id}; Path=/; HttpOnly",
+        }
+        return _create_response(status=302, headers=headers)
 
-    return jsonify({'error': 'Failed to get access token'}), 400
+    return _create_response({"error": "Failed to get access token"}, 400)
 
 
-@app.route('/api/user')
-def get_user():
-    """Get current user profile"""
-    headers = get_auth_header()
+def get_user(event):
+    """Get current user profile."""
+    _, session = _get_session(event)
+    headers = get_auth_header(session)
     if not headers:
-        return jsonify({'error': 'Not authenticated'}), 401
+        return _create_response({"error": "Not authenticated"}, 401)
 
     response = requests.get(f"{SPOTIFY_API_BASE_URL}/me", headers=headers)
-    return jsonify(response.json())
+    return _create_response(response.json())
 
 
-@app.route('/api/search')
-def search_tracks():
-    """Search for tracks"""
-    headers = get_auth_header()
+def search_tracks(event):
+    """Search for tracks."""
+    _, session = _get_session(event)
+    headers = get_auth_header(session)
     if not headers:
-        return jsonify({'error': 'Not authenticated'}), 401
+        return _create_response({"error": "Not authenticated"}, 401)
 
-    query = request.args.get('q', '')
+    query = (event.get("queryStringParameters") or {}).get("q", "")
     if not query:
-        return jsonify({'error': 'Query parameter required'}), 400
+        return _create_response({"error": "Query parameter required"}, 400)
 
-    params = {'q': query, 'type': 'track', 'limit': 20}
-
-    response = requests.get(
-        f"{SPOTIFY_API_BASE_URL}/search", headers=headers, params=params
-    )
-    return jsonify(response.json())
+    params = {"q": query, "type": "track", "limit": 20}
+    response = requests.get(f"{SPOTIFY_API_BASE_URL}/search", headers=headers, params=params)
+    return _create_response(response.json())
 
 
-@app.route('/api/create-playlist', methods=['POST'])
-def create_playlist():
-    """Create a new playlist and add tracks"""
-    headers = get_auth_header()
+def create_playlist(event):
+    """Create a new playlist and add tracks."""
+    _, session = _get_session(event)
+    headers = get_auth_header(session)
     if not headers:
-        return jsonify({'error': 'Not authenticated'}), 401
+        return _create_response({"error": "Not authenticated"}, 401)
 
-    data = request.json
-    playlist_name = data.get('name', 'El vinilo de hoy')
-    track_uris = data.get('track_uris', [])
-
+    try:
+        data = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        data = {}
+    playlist_name = data.get("name", "El vinilo de hoy")
+    track_uris = data.get("track_uris", [])
     if len(track_uris) < 8 or len(track_uris) > 12:
-        return jsonify({'error': 'Playlist must have 8-12 tracks'}), 400
+        return _create_response({"error": "Playlist must have 8-12 tracks"}, 400)
 
-    # Get user ID
-    user_response = requests.get(f"{SPOTIFY_API_BASE_URL}/me", headers=headers)
-    user_id = user_response.json().get('id')
+    user_resp = requests.get(f"{SPOTIFY_API_BASE_URL}/me", headers=headers)
+    user_id = user_resp.json().get("id")
 
-    # Create playlist
     playlist_data = {
-        'name': playlist_name,
-        'description': 'Created with VirtualVinyl - A vinyl-inspired playlist',
-        'public': False,
+        "name": playlist_name,
+        "description": "Created with VirtualVinyl - A vinyl-inspired playlist",
+        "public": False,
     }
-
-    playlist_response = requests.post(
+    playlist_resp = requests.post(
         f"{SPOTIFY_API_BASE_URL}/users/{user_id}/playlists",
-        headers={**headers, 'Content-Type': 'application/json'},
+        headers={**headers, "Content-Type": "application/json"},
         json=playlist_data,
     )
+    if playlist_resp.status_code != 201:
+        return _create_response({"error": "Failed to create playlist"}, 400)
 
-    if playlist_response.status_code != 201:
-        return jsonify({'error': 'Failed to create playlist'}), 400
-
-    playlist = playlist_response.json()
-    playlist_id = playlist['id']
-
-    # Add tracks to playlist
-    tracks_data = {'uris': track_uris}
-    tracks_response = requests.post(
+    playlist = playlist_resp.json()
+    playlist_id = playlist["id"]
+    tracks_data = {"uris": track_uris}
+    tracks_resp = requests.post(
         f"{SPOTIFY_API_BASE_URL}/playlists/{playlist_id}/tracks",
-        headers={**headers, 'Content-Type': 'application/json'},
+        headers={**headers, "Content-Type": "application/json"},
         json=tracks_data,
     )
+    if tracks_resp.status_code != 201:
+        return _create_response({"error": "Failed to add tracks to playlist"}, 400)
 
-    if tracks_response.status_code != 201:
-        return jsonify({'error': 'Failed to add tracks to playlist'}), 400
-
-    return jsonify(
+    return _create_response(
         {
-            'playlist_id': playlist_id,
-            'playlist_url': playlist['external_urls']['spotify'],
-            'message': 'Virtual vinyl created successfully!',
+            "playlist_id": playlist_id,
+            "playlist_url": playlist["external_urls"]["spotify"],
+            "message": "Virtual vinyl created successfully!",
         }
     )
 
 
-@app.route('/api/auth-status')
-def auth_status():
-    """Check if user is authenticated"""
-    return jsonify({'authenticated': 'access_token' in session})
+def auth_status(event):
+    """Check if user is authenticated."""
+    _, session = _get_session(event)
+    return _create_response({"authenticated": bool(session and "access_token" in session)})
 
 
-@app.route('/api/logout', methods=['POST'])
-def logout():
-    """Logout user"""
-    session.clear()
-    return jsonify({'message': 'Logged out successfully'})
-
-
-if __name__ == '__main__':
-    app.run(debug=True, port=5000)
+def logout(event):
+    """Logout user."""
+    session_id, session = _get_session(event)
+    if session_id and session:
+        SESSION_STORE.pop(session_id, None)
+    headers = {"Set-Cookie": "session_id=; Path=/; Max-Age=0"}
+    return _create_response({"message": "Logged out successfully"}, headers=headers)
 
 
 def lambda_handler(event, context):
     """AWS Lambda entry point."""
-    return awsgi.response(app, event, context)
+    path = event.get("rawPath") or event.get("path")
+    method = (
+        event.get("requestContext", {}).get("http", {}).get("method")
+        or event.get("httpMethod")
+    )
+    routes = {
+        ("/login", "GET"): login,
+        ("/callback", "GET"): callback,
+        ("/api/user", "GET"): get_user,
+        ("/api/search", "GET"): search_tracks,
+        ("/api/create-playlist", "POST"): create_playlist,
+        ("/api/auth-status", "GET"): auth_status,
+        ("/api/logout", "POST"): logout,
+    }
+    handler = routes.get((path, method))
+    if handler:
+        return handler(event)
+    return _create_response({"error": "Not found"}, 404)
+

--- a/app.py
+++ b/app.py
@@ -5,17 +5,19 @@ import json
 import os
 import secrets
 from urllib.parse import urlencode
-
-import dotenv
 import requests
 
 # Load environment variables from .env file
-dotenv.load_dotenv()
+try:
+    import dotenv
+    dotenv.load_dotenv()
+except ImportError:
+    print("dotenv module not found, ensure you have it installed if using .env files.")
 
 # Spotify App Credentials (replace with your actual credentials)
 CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
 CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
-REDIRECT_URI = "https://cperales.github.io/VirtualVinyl/callback"
+REDIRECT_URI = os.getenv("LAMBDA_URL") + "/callback"
 
 SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
 SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ except ImportError:
 CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
 CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
 REDIRECT_URI = os.getenv("LAMBDA_URL") + "/callback"
+print("Using REDIRECT_URI:", REDIRECT_URI)
 
 SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
 SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"

--- a/docs/callback.html
+++ b/docs/callback.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=http://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws/callback" />
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <p>If you are not redirected automatically, <a href="http://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws/callback">click here</a>.</p>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 requests==2.31.0
-flask==3.0.0
-flask-cors==4.0.0
 pytest==8.4.0
 dotenv==0.9.9
-awsgi==0.0.5

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,74 +1,84 @@
-import pytest
-from flask import session
-
+import json
 import app
 
 
-@pytest.fixture
-def client():
-    app.app.config['TESTING'] = True
-    with app.app.test_client() as client:
-        yield client
+def invoke_lambda(path, method="GET", query=None, body=None, cookies=None):
+    headers = {}
+    if cookies:
+        headers["cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
+    event = {
+        "rawPath": path,
+        "requestContext": {"http": {"method": method}},
+        "headers": headers,
+    }
+    if query:
+        event["queryStringParameters"] = query
+    if body is not None:
+        event["body"] = json.dumps(body)
+    return app.lambda_handler(event, None)
 
 
 def test_get_auth_header_without_token():
-    with app.app.test_request_context('/'):
-        assert app.get_auth_header() is None
+    assert app.get_auth_header({}) is None
 
 
 def test_get_auth_header_with_token():
-    with app.app.test_request_context('/'):
-        session['access_token'] = 'abc123'
-        assert app.get_auth_header() == {'Authorization': 'Bearer abc123'}
+    assert app.get_auth_header({"access_token": "abc123"}) == {
+        "Authorization": "Bearer abc123"
+    }
 
 
-def test_login_sets_state_and_redirects(client):
-    response = client.get('/login')
-    assert response.status_code == 302
-    assert 'accounts.spotify.com/authorize' in response.location
-    with client.session_transaction() as sess:
-        assert 'state' in sess
+def test_login_sets_state_and_redirects():
+    response = invoke_lambda("/login")
+    assert response["statusCode"] == 302
+    assert "accounts.spotify.com/authorize" in response["headers"]["Location"]
+    cookie = response["headers"]["Set-Cookie"]
+    session_id = cookie.split("=", 1)[1].split(";", 1)[0]
+    assert session_id in app.SESSION_STORE
+    assert "state" in app.SESSION_STORE[session_id]
 
 
-def test_search_requires_auth(client):
-    response = client.get('/api/search?q=test')
-    assert response.status_code == 401
-    assert response.get_json() == {'error': 'Not authenticated'}
+def test_search_requires_auth():
+    response = invoke_lambda("/api/search", query={"q": "test"})
+    assert response["statusCode"] == 401
+    assert json.loads(response["body"]) == {"error": "Not authenticated"}
 
 
-def test_search_requires_query(client):
-    with client.session_transaction() as sess:
-        sess['access_token'] = 'token'
-    response = client.get('/api/search')
-    assert response.status_code == 400
-    assert response.get_json() == {'error': 'Query parameter required'}
+def test_search_requires_query():
+    session_id = "s1"
+    app.SESSION_STORE[session_id] = {"access_token": "token"}
+    response = invoke_lambda("/api/search", cookies={"session_id": session_id})
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"]) == {"error": "Query parameter required"}
 
 
-def test_create_playlist_invalid_track_count(client):
-    with client.session_transaction() as sess:
-        sess['access_token'] = 'token'
-    response = client.post(
-        '/api/create-playlist',
-        json={'track_uris': ['a', 'b']},
+def test_create_playlist_invalid_track_count():
+    session_id = "s2"
+    app.SESSION_STORE[session_id] = {"access_token": "token"}
+    response = invoke_lambda(
+        "/api/create-playlist",
+        method="POST",
+        body={"track_uris": ["a", "b"]},
+        cookies={"session_id": session_id},
     )
-    assert response.status_code == 400
-    assert response.get_json() == {'error': 'Playlist must have 8-12 tracks'}
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"]) == {"error": "Playlist must have 8-12 tracks"}
 
 
-def test_auth_status(client):
-    response = client.get('/api/auth-status')
-    assert response.get_json() == {'authenticated': False}
-    with client.session_transaction() as sess:
-        sess['access_token'] = 'token'
-    response = client.get('/api/auth-status')
-    assert response.get_json() == {'authenticated': True}
+def test_auth_status():
+    response = invoke_lambda("/api/auth-status")
+    assert json.loads(response["body"]) == {"authenticated": False}
+    session_id = "s3"
+    app.SESSION_STORE[session_id] = {"access_token": "token"}
+    response = invoke_lambda("/api/auth-status", cookies={"session_id": session_id})
+    assert json.loads(response["body"]) == {"authenticated": True}
 
 
-def test_logout_clears_session(client):
-    with client.session_transaction() as sess:
-        sess['access_token'] = 'token'
-    response = client.post('/api/logout')
-    assert response.status_code == 200
-    assert response.get_json()['message'] == 'Logged out successfully'
-    with client.session_transaction() as sess:
-        assert 'access_token' not in sess
+def test_logout_clears_session():
+    session_id = "s4"
+    app.SESSION_STORE[session_id] = {"access_token": "token"}
+    response = invoke_lambda("/api/logout", method="POST", cookies={"session_id": session_id})
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"])["message"] == "Logged out successfully"
+    assert session_id not in app.SESSION_STORE
+


### PR DESCRIPTION
## Summary
- rework `app.py` to eliminate Flask usage and provide a pure Lambda handler
- drop Flask related packages from `requirements.txt`
- adjust tests to exercise Lambda style functions
- document Flask removal in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bf4b0971c83288593d6dae8d9cc47