### PR TITLE
Fix Spotify callback redirect

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@
 
 # Bugs
 [x] After logging in Spotify, I got `Missing required parameter; client_id`
+[x] "Invalid callback" error after login was caused by callback page dropping query parameters
 
 # Notes
 [x] Redesigned Dash app to show a vinyl image and nicer styling

--- a/docs/callback.html
+++ b/docs/callback.html
@@ -1,10 +1,20 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=http://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws/callback" />
     <title>Redirecting...</title>
+    <script>
+      const qs = window.location.search;
+      const base = 'https://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws/callback';
+      window.location.href = base + qs;
+    </script>
   </head>
   <body>
-    <p>If you are not redirected automatically, <a href="http://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws/callback">click here</a>.</p>
+    <p>If you are not redirected automatically,
+      <a id="redir" href="#">click here</a>.</p>
+    <script>
+      document.getElementById('redir').href =
+        'https://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws/callback' +
+        window.location.search;
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- keep Spotify OAuth query parameters when redirecting from GitHub Pages
- document fix in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c00968ba483288399dbaaa2e31df1