### PR TITLE
Implement playlist selection after login

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 [x] Convert the backend into an AWS Lambda function
 [x] Remove the Flask dependency from the backend
 [x] Add more loggings in the backend, replace prints for loggings
-[ ] After logging, the app should brings you to a website where
+[x] After logging, the app should brings you to a website where
     - User can select manually the songs from their most listened to be included in a new playist (called `Virtual Vinyl`)
     - A link appears to the new playlist
 

--- a/app.py
+++ b/app.py
@@ -167,6 +167,23 @@ def search_tracks(event):
     return _create_response(response.json())
 
 
+def top_tracks(event):
+    """Return user's top tracks."""
+    _, session = _get_session(event)
+    logger.info("Fetching user's top tracks")
+    headers = get_auth_header(session)
+    if not headers:
+        return _create_response({"error": "Not authenticated"}, 401)
+
+    params = {"limit": 20}
+    resp = requests.get(f"{SPOTIFY_API_BASE_URL}/me/top/tracks", headers=headers, params=params)
+    if resp.status_code != 200:
+        logger.error("Failed to fetch top tracks")
+        return _create_response({"error": "Failed to fetch top tracks"}, 400)
+
+    return _create_response(resp.json())
+
+
 def create_playlist(event):
     """Create a new playlist and add tracks."""
     _, session = _get_session(event)
@@ -256,6 +273,7 @@ def lambda_handler(event, context):
         ("/callback", "GET"): callback,
         ("/api/user", "GET"): get_user,
         ("/api/search", "GET"): search_tracks,
+        ("/api/top-tracks", "GET"): top_tracks,
         ("/api/create-playlist", "POST"): create_playlist,
         ("/api/auth-status", "GET"): auth_status,
         ("/api/logout", "POST"): logout,

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,15 +24,75 @@
     <h1>Virtual Vinyl</h1>
     <p>Create a curated playlist of 8 to 12 songs.</p>
     <img src="img/vinyl.jpg" alt="Vinyl" class="vinyl-img">
-    <div>
+    <div id="login-section">
         <button id="login-btn">Login with Spotify</button>
+        <div id="login-status"></div>
     </div>
-    <div id="login-status"></div>
+
+    <div id="selection-section" style="display:none;">
+        <h2>Select Your Tracks</h2>
+        <div id="track-selection"></div>
+        <button id="create-btn">Create Playlist</button>
+        <div id="playlist-link"></div>
+    </div>
     <script>
         const BACKEND_URL = 'https://xrzlv3xlqqgaor44hhddzfrxui0xefxc.lambda-url.us-east-1.on.aws';
         document.getElementById('login-btn').addEventListener('click', () => {
             window.open(`${BACKEND_URL}/login`, '_blank');
             document.getElementById('login-status').textContent = 'Redirecting to Spotify login...';
+        });
+
+        function fetchTopTracks() {
+            fetch(`${BACKEND_URL}/api/top-tracks`, { credentials: 'include' })
+                .then(r => r.json())
+                .then(d => showTracks(d.items || []));
+        }
+
+        function showTracks(tracks) {
+            const cont = document.getElementById('track-selection');
+            cont.innerHTML = '';
+            tracks.forEach(t => {
+                const div = document.createElement('div');
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.value = t.uri;
+                div.appendChild(cb);
+                div.appendChild(document.createTextNode(` ${t.name} - ${t.artists[0].name}`));
+                cont.appendChild(div);
+            });
+        }
+
+        function createPlaylist() {
+            const selected = Array.from(document.querySelectorAll('#track-selection input:checked')).map(cb => cb.value);
+            if (selected.length < 8 || selected.length > 12) {
+                alert('Please select between 8 and 12 songs.');
+                return;
+            }
+            fetch(`${BACKEND_URL}/api/create-playlist`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ track_uris: selected })
+            })
+            .then(r => r.json())
+            .then(d => {
+                const linkDiv = document.getElementById('playlist-link');
+                if (d.playlist_url) {
+                    linkDiv.innerHTML = `<a href="${d.playlist_url}" target="_blank">Open your new playlist</a>`;
+                } else {
+                    linkDiv.textContent = 'Failed to create playlist';
+                }
+            });
+        }
+
+        document.getElementById('create-btn').addEventListener('click', createPlaylist);
+
+        window.addEventListener('load', () => {
+            if (new URLSearchParams(window.location.search).get('auth') === 'success') {
+                document.getElementById('login-section').style.display = 'none';
+                document.getElementById('selection-section').style.display = 'block';
+                fetchTopTracks();
+            }
         });
     </script>
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,6 +52,12 @@ def test_search_requires_query():
     assert json.loads(response["body"]) == {"error": "Query parameter required"}
 
 
+def test_top_tracks_requires_auth():
+    response = invoke_lambda("/api/top-tracks")
+    assert response["statusCode"] == 401
+    assert json.loads(response["body"]) == {"error": "Not authenticated"}
+
+
 def test_create_playlist_invalid_track_count():
     session_id = "s2"
     app.SESSION_STORE[session_id] = {"access_token": "token"}


### PR DESCRIPTION
## Summary
- enable song picking after authentication
- fetch user's top tracks via new endpoint
- display track selection page on the frontend
- update tests for new endpoint
- mark TODO as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c0a97cad88328bb40ab9c4e61633f