### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,44 @@
+# Deploy static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ npm run build
 ```sh
 npm run lint
 ```
+
+### View on GitHub Pages
+
+After pushing to the `main` branch, the project is automatically built
+and deployed using GitHub Actions. You can access the live site at
+<https://cperales.github.io/VirtualVinyl>.

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes
 })
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/VirtualVinyl/',
   plugins: [
     vue(),
     vueDevTools(),


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow
- configure Vite base path for GitHub Pages
- update router to respect Vite base URL
- document GitHub Pages URL

## Testing
- `npm run lint` *(fails: 'no-unused-vars' errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68506b21128c8328a6724794b74ee1bb