### PR TITLE
Add robots.txt and rename site to Virtual Vinyl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VirtualVinyl
+# Virtual Vinyl
 
 This template should help get you started developing with Vue 3 in Vite.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VirtualVinyl - Vintage Playlist Creator</title>
+    <title>Virtual Vinyl - Vintage Playlist Creator</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Crimson+Text:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/composables/useSpotify.js
+++ b/src/composables/useSpotify.js
@@ -30,7 +30,7 @@ export function useSpotify() {
   const setupPlayer = () => {
     if (!window.Spotify || player) return
     player = new window.Spotify.Player({
-      name: 'VirtualVinyl',
+      name: 'Virtual Vinyl',
       getOAuthToken: (cb) => cb(spotifyApi.value.getAccessToken()),
     })
 
@@ -167,7 +167,7 @@ export function useSpotify() {
     try {
       const playlist = await spotifyApi.value.playlists.createPlaylist(user.value.id, {
         name,
-        description: 'Created with VirtualVinyl',
+        description: 'Created with Virtual Vinyl',
         public: false,
       })
 

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -3,7 +3,7 @@
 		<div class="vinyl-record">
 			<div class="vinyl-center">
 				<div class="vinyl-label">
-					<h1 class="app-title">VirtualVinyl</h1>
+                                        <h1 class="app-title">Virtual Vinyl</h1>
 					<p class="app-subtitle">Vintage Playlist Creator</p>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- add `public/robots.txt`
- update page title and header text to "Virtual Vinyl"
- adjust Spotify player name and playlist description
- update project README heading

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68512f0c13d88328b95652423092fa76