### PR TITLE
Fix logout clearing Spotify tokens

### DIFF
--- a/src/composables/useSpotify.js
+++ b/src/composables/useSpotify.js
@@ -122,8 +122,10 @@ export function useSpotify() {
     topTracks.value = []
     selectedTracks.value = []
 
-    // Clear any stored tokens (SDK handles this internally)
-    localStorage.removeItem('spotify-sdk')
+    // Clear any stored tokens from the SDK
+    Object.keys(localStorage)
+      .filter((key) => key.startsWith('spotify-sdk'))
+      .forEach((key) => localStorage.removeItem(key))
   }
 
   const getCurrentUser = async () => {


### PR DESCRIPTION
## Summary
- clear all spotify-sdk tokens on logout

## Testing
- `npm run lint`
- `npm run build`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_68514848c9b48328b955128722446f6a