### PR TITLE
Fix: Update Spotify redirect URI to include /callback

### DIFF
--- a/src/composables/useSpotify.js
+++ b/src/composables/useSpotify.js
@@ -2,7 +2,7 @@ import { ref, computed, onMounted } from 'vue'
 import { SpotifyApi } from '@spotify/web-api-ts-sdk'
 
 const CLIENT_ID = '766875441cc149e79ed8aff4fb1be351' // Replace with your Spotify Client ID
-const REDIRECT_URI = 'https://cperales.github.io/VirtualVinyl'
+const REDIRECT_URI = 'https://cperales.github.io/VirtualVinyl/callback'
 const SCOPES = [
   'user-read-private',
   'user-read-email',


### PR DESCRIPTION
This change updates the REDIRECT_URI in `useSpotify.js` to `https://cperales.github.io/VirtualVinyl/callback`.

This ensures that after a successful Spotify login, the user is redirected to the `/callback` path defined in the Vue router, which then correctly redirects to the `/home` page.

This addresses the issue where the application would not load the home page after Spotify login on the GitHub Pages site because the previous redirect URI (`https://cperales.github.io/VirtualVinyl`) did not explicitly trigger a route in the Vue router after the base path was handled by `window.history.replaceState`.

Note: The corresponding Redirect URI must also be updated in the Spotify Developer Dashboard for this fix to be effective.