### PR TITLE
Add Streamlit version with Python clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Python
+__pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -45,3 +45,28 @@ npx vitest run
 After pushing to the `main` branch, the project is automatically built
 and deployed using GitHub Actions. You can access the live site at
 <https://cperales.github.io/VirtualVinyl>.
+
+## Streamlit App
+
+A basic Streamlit interface reproduces the Virtual Vinyl experience in Python.
+
+### Setup
+
+```sh
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Set the following environment variables for authentication:
+
+- `CLIENT_ID` and `CLIENT_SECRET` – Spotify credentials
+- `REDIRECT_URI` – Spotify redirect URI
+- `TIDAL_CLIENT_ID` – TIDAL application id
+- `TIDAL_REDIRECT_URI` – TIDAL redirect URI
+
+### Run
+
+```sh
+streamlit run streamlit_app/app.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+spotipy
+requests

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,0 +1,73 @@
+import os
+import streamlit as st
+from playlist import PlaylistManager
+from spotify_client import SpotifyClient
+from tidal_client import TidalClient
+
+st.set_page_config(page_title="Virtual Vinyl")
+
+if "spotify" not in st.session_state:
+    st.session_state.spotify = SpotifyClient()
+if "tidal" not in st.session_state:
+    st.session_state.tidal = TidalClient()
+if "playlist" not in st.session_state:
+    st.session_state.playlist = PlaylistManager()
+
+sp = st.session_state.spotify
+td = st.session_state.tidal
+pl = st.session_state.playlist
+
+st.title("Virtual Vinyl")
+
+# Authentication buttons
+col1, col2 = st.columns(2)
+with col1:
+    if not sp.is_authenticated():
+        if st.button("Login with Spotify"):
+            auth_url = sp.login_url()
+            st.write("[Open login]({})".format(auth_url))
+    else:
+        user = sp.current_user()
+        st.write(f"Logged in as {user['display_name']}")
+
+with col2:
+    if not td.is_authenticated():
+        if st.button("Login with TIDAL"):
+            auth_url = td.login_url("state123")
+            st.write("[Open login]({})".format(auth_url))
+    else:
+        st.write("TIDAL authenticated")
+
+# Handle code from URL params
+code = st.experimental_get_query_params().get("code")
+if code and not sp.is_authenticated():
+    sp.handle_callback(code[0])
+if code and not td.is_authenticated():
+    td.handle_callback(code[0])
+
+if sp.is_authenticated():
+    if "tracks" not in st.session_state:
+        st.session_state.tracks = sp.top_tracks()
+    search = st.text_input("Search tracks")
+    if search:
+        tracks = sp.search_tracks(search)
+    else:
+        tracks = st.session_state.tracks
+
+    for t in tracks:
+        cols = st.columns([4,1])
+        cols[0].write(f"{t['name']} - {', '.join(a['name'] for a in t['artists'])}")
+        if st.button("Select", key=t['id']):
+            pl.toggle_track({"id": t['id'], "uri": t['uri']})
+
+    st.write(f"Selected {len(pl.selected_tracks)} tracks")
+    playlist_name = st.text_input("Playlist name")
+    if st.button("Create Spotify Playlist") and playlist_name:
+        track_uris = [t['uri'] for t in pl.selected_tracks]
+        playlist = sp.create_playlist(playlist_name, track_uris)
+        if playlist:
+            st.success(f"Created playlist {playlist['name']}")
+            st.write(playlist.get('external_urls', {}).get('spotify'))
+            pl.selected_tracks = []
+
+

--- a/streamlit_app/playlist.py
+++ b/streamlit_app/playlist.py
@@ -1,0 +1,13 @@
+class PlaylistManager:
+    """Manage track selection for playlist creation."""
+
+    def __init__(self):
+        self.selected_tracks = []
+
+    def toggle_track(self, track):
+        """Add or remove track from selection, max 10 tracks."""
+        existing = next((t for t in self.selected_tracks if t['id'] == track['id']), None)
+        if existing:
+            self.selected_tracks = [t for t in self.selected_tracks if t['id'] != track['id']]
+        elif len(self.selected_tracks) < 10:
+            self.selected_tracks.append(track)

--- a/streamlit_app/spotify_client.py
+++ b/streamlit_app/spotify_client.py
@@ -1,0 +1,68 @@
+import os
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+
+
+class SpotifyClient:
+    """Minimal wrapper around spotipy for Virtual Vinyl."""
+
+    def __init__(self):
+        self.client = None
+        self.auth_manager = SpotifyOAuth(
+            client_id=os.getenv('CLIENT_ID'),
+            client_secret=os.getenv('CLIENT_SECRET'),
+            redirect_uri=os.getenv('REDIRECT_URI'),
+            scope='user-read-private user-read-email user-top-read playlist-modify-public playlist-modify-private',
+            open_browser=False,
+        )
+
+    def login_url(self):
+        return self.auth_manager.get_authorize_url()
+
+    def handle_callback(self, code):
+        token_info = self.auth_manager.get_access_token(code)
+        self.client = spotipy.Spotify(auth=token_info['access_token'])
+
+    def is_authenticated(self):
+        return self.client is not None
+
+    def current_user(self):
+        if not self.client:
+            return None
+        return self.client.current_user()
+
+    def top_tracks(self, limit=50):
+        if not self.client:
+            return []
+        results = self.client.current_user_top_tracks(limit=limit)
+        return results.get('items', [])
+
+    def search_tracks(self, query, limit=50):
+        if not self.client or not query:
+            return []
+        results = self.client.search(q=query, type='track', limit=limit)
+        return results['tracks']['items']
+
+    def create_playlist(self, name, track_uris):
+        if not self.client:
+            return None
+        user = self.client.current_user()
+        playlist = self.client.user_playlist_create(user['id'], name)
+        if track_uris:
+            self.client.playlist_add_items(playlist['id'], track_uris)
+        return playlist
+
+    def play_track(self, uri):
+        if not self.client:
+            return
+        try:
+            self.client.start_playback(uris=[uri])
+        except spotipy.SpotifyException:
+            pass
+
+    def pause(self):
+        if self.client:
+            try:
+                self.client.pause_playback()
+            except spotipy.SpotifyException:
+                pass

--- a/streamlit_app/tests/test_playlist.py
+++ b/streamlit_app/tests/test_playlist.py
@@ -1,0 +1,23 @@
+from streamlit_app.playlist import PlaylistManager
+
+
+def test_toggle_adds_track():
+    pm = PlaylistManager()
+    pm.toggle_track({'id': '1'})
+    assert len(pm.selected_tracks) == 1
+    assert pm.selected_tracks[0]['id'] == '1'
+
+
+def test_toggle_removes_track():
+    pm = PlaylistManager()
+    track = {'id': '1'}
+    pm.toggle_track(track)
+    pm.toggle_track(track)
+    assert len(pm.selected_tracks) == 0
+
+
+def test_limit_selection_to_10():
+    pm = PlaylistManager()
+    for i in range(12):
+        pm.toggle_track({'id': str(i)})
+    assert len(pm.selected_tracks) == 10

--- a/streamlit_app/tidal_client.py
+++ b/streamlit_app/tidal_client.py
@@ -1,0 +1,78 @@
+import os
+import requests
+
+
+class TidalClient:
+    """Minimal TIDAL API wrapper."""
+
+    AUTH_URL = "https://auth.tidal.com/v1/oauth2/token"
+    API_URL = "https://api.tidal.com/v1"
+
+    def __init__(self):
+        self.access_token = None
+        self.client_id = os.getenv("TIDAL_CLIENT_ID")
+        self.redirect_uri = os.getenv("TIDAL_REDIRECT_URI")
+
+    def login_url(self, state):
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+            "state": state,
+            "scope": "r_usr w_usr r_sub w_sub",
+        }
+        query = "&".join(f"{k}={requests.utils.quote(str(v))}" for k, v in params.items())
+        return f"https://login.tidal.com/authorize?{query}"
+
+    def handle_callback(self, code):
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+        }
+        resp = requests.post(self.AUTH_URL, data=data)
+        if resp.ok:
+            payload = resp.json()
+            self.access_token = payload.get("access_token")
+
+    def is_authenticated(self):
+        return self.access_token is not None
+
+    def search_tracks(self, query):
+        if not self.access_token or not query:
+            return []
+        resp = requests.get(
+            f"{self.API_URL}/search/tracks",
+            params={"query": query, "limit": 50},
+            headers={"Authorization": f"Bearer {self.access_token}"},
+        )
+        if resp.ok:
+            data = resp.json()
+            return data.get("items", [])
+        return []
+
+    def create_playlist(self, user_id, name, track_ids):
+        if not self.access_token:
+            return None
+        resp = requests.post(
+            f"{self.API_URL}/users/{user_id}/playlists",
+            headers={
+                "Authorization": f"Bearer {self.access_token}",
+                "Content-Type": "application/json",
+            },
+            json={"title": name, "description": "Created with Virtual Vinyl", "visibility": "PRIVATE"},
+        )
+        if not resp.ok:
+            return None
+        playlist = resp.json()
+        if track_ids:
+            requests.post(
+                f"{self.API_URL}/playlists/{playlist['uuid']}/items",
+                headers={
+                    "Authorization": f"Bearer {self.access_token}",
+                    "Content-Type": "application/json",
+                },
+                json={"trackIds": track_ids, "onDupes": "SKIP"},
+            )
+        return playlist


### PR DESCRIPTION
## Summary
- add Streamlit project with Spotify and TIDAL API wrappers
- manage playlist selection in Python
- include basic pytest tests
- document setup and usage of the Streamlit app
- ignore Python artifacts

## Testing
- `npx vitest run`
- `python -m pytest streamlit_app/tests/test_playlist.py -vv`


------
https://chatgpt.com/codex/tasks/task_b_68776e8ba420832882cae5f4b0fd45b1