### PR TITLE
Use SPOTIPY_* vars for Spotify auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY streamlit_app ./streamlit_app
 
 # Copy environment variables (make sure to create this file)
 # COPY .env ./
-ENV SPOTIFY_CLIENT_API=YOUR_CLIENT_API
-ENV SPOTIFY_CLIENT_SECRET=YOUR_CLIENT_SECRET
+ENV SPOTIPY_CLIENT_ID=YOUR_CLIENT_ID
+ENV SPOTIPY_CLIENT_SECRET=YOUR_CLIENT_SECRET
 ENV REDIRECT_URI=URL
 
 # Set Streamlit configuration

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pip install -r requirements.txt
 
 Set the following environment variables for authentication:
 
-- `CLIENT_ID` and `CLIENT_SECRET` – Spotify credentials
+- `SPOTIPY_CLIENT_ID` and `SPOTIPY_CLIENT_SECRET` – Spotify credentials
 - `REDIRECT_URI` – Spotify redirect URI
 - `TIDAL_CLIENT_ID` – TIDAL application id
 - `TIDAL_REDIRECT_URI` – TIDAL redirect URI

--- a/streamlit_app/spotify_client.py
+++ b/streamlit_app/spotify_client.py
@@ -8,10 +8,10 @@ load_dotenv(dotenv_path='.env',
             verbose=True,
             override=True)
 
-SPOTIFY_CLIENT_API = os.getenv('SPOTIFY_CLIENT_API')
-logging.warning("SPOTIFY_CLIENT_API: %s", SPOTIFY_CLIENT_API)
-SPOTIFY_SECRET_API = os.getenv('SPOTIFY_SECRET_API')
-logging.warning("SPOTIFY_SECRET_API: %s", SPOTIFY_SECRET_API)
+SPOTIPY_CLIENT_ID = os.getenv('SPOTIPY_CLIENT_ID')
+logging.warning("SPOTIPY_CLIENT_ID: %s", SPOTIPY_CLIENT_ID)
+SPOTIPY_CLIENT_SECRET = os.getenv('SPOTIPY_CLIENT_SECRET')
+logging.warning("SPOTIPY_CLIENT_SECRET: %s", SPOTIPY_CLIENT_SECRET)
 REDIRECT_URI = os.getenv('REDIRECT_URI')
 logging.warning("REDIRECT_URI: %s", REDIRECT_URI)
 
@@ -21,8 +21,8 @@ class SpotifyClient:
     def __init__(self):
         self.client = None
         self.auth_manager = SpotifyOAuth(
-            client_id=SPOTIFY_CLIENT_API,
-            client_secret=SPOTIFY_SECRET_API,
+            client_id=SPOTIPY_CLIENT_ID,
+            client_secret=SPOTIPY_CLIENT_SECRET,
             redirect_uri=REDIRECT_URI,
             scope='user-read-private user-read-email user-top-read playlist-modify-public playlist-modify-private',
             open_browser=False,


### PR DESCRIPTION
## Summary
- switch to SPOTIPY_CLIENT_ID and SPOTIPY_CLIENT_SECRET
- update README instructions
- adjust Dockerfile defaults

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687de9e173c0832891f7a18cd1ee2ec1