### PR TITLE
Format streamlit_app per pycodestyle

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -55,8 +55,9 @@ if sp.is_authenticated():
         tracks = st.session_state.tracks
 
     for t in tracks:
-        cols = st.columns([4,1])
-        cols[0].write(f"{t['name']} - {', '.join(a['name'] for a in t['artists'])}")
+        cols = st.columns([4, 1])
+        artists = ', '.join(a['name'] for a in t['artists'])
+        cols[0].write(f"{t['name']} - {artists}")
         if st.button("Select", key=t['id']):
             pl.toggle_track({"id": t['id'], "uri": t['uri']})
 
@@ -69,5 +70,3 @@ if sp.is_authenticated():
             st.success(f"Created playlist {playlist['name']}")
             st.write(playlist.get('external_urls', {}).get('spotify'))
             pl.selected_tracks = []
-
-

--- a/streamlit_app/playlist.py
+++ b/streamlit_app/playlist.py
@@ -6,8 +6,13 @@ class PlaylistManager:
 
     def toggle_track(self, track):
         """Add or remove track from selection, max 10 tracks."""
-        existing = next((t for t in self.selected_tracks if t['id'] == track['id']), None)
+        existing = next(
+            (t for t in self.selected_tracks if t['id'] == track['id']),
+            None,
+        )
         if existing:
-            self.selected_tracks = [t for t in self.selected_tracks if t['id'] != track['id']]
+            self.selected_tracks = [
+                t for t in self.selected_tracks if t['id'] != track['id']
+            ]
         elif len(self.selected_tracks) < 10:
             self.selected_tracks.append(track)

--- a/streamlit_app/spotify_client.py
+++ b/streamlit_app/spotify_client.py
@@ -15,6 +15,7 @@ logging.warning("SPOTIPY_CLIENT_SECRET: %s", SPOTIPY_CLIENT_SECRET)
 REDIRECT_URI = os.getenv('REDIRECT_URI')
 logging.warning("REDIRECT_URI: %s", REDIRECT_URI)
 
+
 class SpotifyClient:
     """Minimal wrapper around spotipy for Virtual Vinyl."""
 
@@ -24,7 +25,10 @@ class SpotifyClient:
             client_id=SPOTIPY_CLIENT_ID,
             client_secret=SPOTIPY_CLIENT_SECRET,
             redirect_uri=REDIRECT_URI,
-            scope='user-read-private user-read-email user-top-read playlist-modify-public playlist-modify-private',
+            scope=(
+                'user-read-private user-read-email user-top-read '
+                'playlist-modify-public playlist-modify-private'
+            ),
             open_browser=False,
         )
 

--- a/streamlit_app/tidal_client.py
+++ b/streamlit_app/tidal_client.py
@@ -21,7 +21,9 @@ class TidalClient:
             "state": state,
             "scope": "r_usr w_usr r_sub w_sub",
         }
-        query = "&".join(f"{k}={requests.utils.quote(str(v))}" for k, v in params.items())
+        query = "&".join(
+            f"{k}={requests.utils.quote(str(v))}" for k, v in params.items()
+        )
         return f"https://login.tidal.com/authorize?{query}"
 
     def handle_callback(self, code):
@@ -61,7 +63,11 @@ class TidalClient:
                 "Authorization": f"Bearer {self.access_token}",
                 "Content-Type": "application/json",
             },
-            json={"title": name, "description": "Created with Virtual Vinyl", "visibility": "PRIVATE"},
+            json={
+                "title": name,
+                "description": "Created with Virtual Vinyl",
+                "visibility": "PRIVATE",
+            },
         )
         if not resp.ok:
             return None


### PR DESCRIPTION
## Summary
- clean up `streamlit_app` files so that `pycodestyle` passes
- tweak column spacing in the Streamlit app
- wrap long lines in playlist manager, Spotify and Tidal clients

## Testing
- `pycodestyle streamlit_app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687dfa2f49ac8328bd23df3aa9791e87