### PR TITLE
Add setup.py and fix env vars in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='virtualvinyl',
+    version='0.0.0',
+    packages=find_packages(),
+)

--- a/streamlit_app/tests/test_auth.py
+++ b/streamlit_app/tests/test_auth.py
@@ -13,8 +13,8 @@ def reload_module(module_name):
 
 
 def test_spotify_oauth_url(monkeypatch):
-    monkeypatch.setenv("SPOTIFY_CLIENT_API", "cid")
-    monkeypatch.setenv("SPOTIFY_SECRET_API", "secret")
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "cid")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "secret")
     monkeypatch.setenv("REDIRECT_URI", "http://localhost/callback")
     sc = reload_module("streamlit_app.spotify_client")
     client = sc.SpotifyClient()
@@ -40,12 +40,12 @@ def test_tidal_oauth_url(monkeypatch):
 
 
 def test_spotify_missing_credentials(monkeypatch):
-    monkeypatch.delenv("SPOTIFY_CLIENT_API", raising=False)
-    monkeypatch.delenv("SPOTIFY_SECRET_API", raising=False)
+    monkeypatch.delenv("SPOTIPY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SPOTIPY_CLIENT_SECRET", raising=False)
     monkeypatch.delenv("REDIRECT_URI", raising=False)
     sc = reload_module("streamlit_app.spotify_client")
-    sc.SPOTIFY_CLIENT_API = ""
-    sc.SPOTIFY_SECRET_API = ""
+    sc.SPOTIPY_CLIENT_ID = ""
+    sc.SPOTIPY_CLIENT_SECRET = ""
     sc.REDIRECT_URI = ""
     with pytest.raises(Exception):
         sc.SpotifyClient()

--- a/streamlit_app/tests/test_playlist_creation.py
+++ b/streamlit_app/tests/test_playlist_creation.py
@@ -10,8 +10,8 @@ def reload_module(module_name):
 
 
 def test_create_playlist(monkeypatch):
-    monkeypatch.setenv("SPOTIFY_CLIENT_API", "cid")
-    monkeypatch.setenv("SPOTIFY_SECRET_API", "secret")
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "cid")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "secret")
     monkeypatch.setenv("REDIRECT_URI", "http://localhost/callback")
     sc = reload_module("streamlit_app.spotify_client")
     client = sc.SpotifyClient()


### PR DESCRIPTION
## Summary
- add minimal `setup.py` for Python packaging
- align environment variable names in tests with the code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687dfa37655c83289c162069208a6450