### PR TITLE
Remove secret logging

### DIFF
--- a/streamlit_app/spotify_client.py
+++ b/streamlit_app/spotify_client.py
@@ -8,12 +8,12 @@ load_dotenv(dotenv_path='.env',
             verbose=True,
             override=False)
 
-SPOTIPY_CLIENT_ID = os.getenv('SPOTIPY_CLIENT_ID')
-logging.warning("SPOTIPY_CLIENT_ID: %s", SPOTIPY_CLIENT_ID)
-SPOTIPY_CLIENT_SECRET = os.getenv('SPOTIPY_CLIENT_SECRET')
-logging.warning("SPOTIPY_CLIENT_SECRET: %s", SPOTIPY_CLIENT_SECRET)
-REDIRECT_URI = os.getenv('REDIRECT_URI')
-logging.warning("REDIRECT_URI: %s", REDIRECT_URI)
+SPOTIPY_CLIENT_ID = os.getenv("SPOTIPY_CLIENT_ID")
+SPOTIPY_CLIENT_SECRET = os.getenv("SPOTIPY_CLIENT_SECRET")
+REDIRECT_URI = os.getenv("REDIRECT_URI")
+
+if not SPOTIPY_CLIENT_ID or not SPOTIPY_CLIENT_SECRET:
+    logging.warning("Spotify credentials are not fully set")
 
 class SpotifyClient:
     """Minimal wrapper around spotipy for Virtual Vinyl."""

--- a/streamlit_app/tests/test_auth.py
+++ b/streamlit_app/tests/test_auth.py
@@ -13,8 +13,8 @@ def reload_module(module_name):
 
 
 def test_spotify_oauth_url(monkeypatch):
-    monkeypatch.setenv("SPOTIFY_CLIENT_API", "cid")
-    monkeypatch.setenv("SPOTIFY_SECRET_API", "secret")
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "cid")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "secret")
     monkeypatch.setenv("REDIRECT_URI", "http://localhost/callback")
     sc = reload_module("streamlit_app.spotify_client")
     client = sc.SpotifyClient()
@@ -40,12 +40,12 @@ def test_tidal_oauth_url(monkeypatch):
 
 
 def test_spotify_missing_credentials(monkeypatch):
-    monkeypatch.delenv("SPOTIFY_CLIENT_API", raising=False)
-    monkeypatch.delenv("SPOTIFY_SECRET_API", raising=False)
+    monkeypatch.delenv("SPOTIPY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SPOTIPY_CLIENT_SECRET", raising=False)
     monkeypatch.delenv("REDIRECT_URI", raising=False)
     sc = reload_module("streamlit_app.spotify_client")
-    sc.SPOTIFY_CLIENT_API = ""
-    sc.SPOTIFY_SECRET_API = ""
+    sc.SPOTIPY_CLIENT_ID = ""
+    sc.SPOTIPY_CLIENT_SECRET = ""
     sc.REDIRECT_URI = ""
     with pytest.raises(Exception):
         sc.SpotifyClient()

--- a/streamlit_app/tests/test_playlist_creation.py
+++ b/streamlit_app/tests/test_playlist_creation.py
@@ -10,8 +10,8 @@ def reload_module(module_name):
 
 
 def test_create_playlist(monkeypatch):
-    monkeypatch.setenv("SPOTIFY_CLIENT_API", "cid")
-    monkeypatch.setenv("SPOTIFY_SECRET_API", "secret")
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "cid")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "secret")
     monkeypatch.setenv("REDIRECT_URI", "http://localhost/callback")
     sc = reload_module("streamlit_app.spotify_client")
     client = sc.SpotifyClient()


### PR DESCRIPTION
## Summary
- stop logging raw Spotify credentials
- update tests to use the new SPOTIPY_* env vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687dfa4b1ae8832891b05179a9564943