### PR TITLE
Add Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Set the following environment variables for authentication:
 streamlit run streamlit_app/app.py
 ```
 
+### Flask Version
+
+You can also run the web interface with Flask:
+
+```sh
+flask --app flask_app.app run
+```
+
 ### Python Tests
 
 Run the Streamlit backend tests with `pytest`:

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -1,0 +1,11 @@
+import os
+from flask import Flask
+from flask_session import Session
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', 'secret')
+app.config['SESSION_TYPE'] = 'filesystem'
+Session(app)
+
+from .routes import bp  # noqa: E402
+app.register_blueprint(bp)

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -1,0 +1,5 @@
+from . import app
+from . import routes  # noqa: F401
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/flask_app/routes.py
+++ b/flask_app/routes.py
@@ -1,0 +1,109 @@
+import uuid
+from flask import render_template, session, request, redirect, url_for, Blueprint
+
+from streamlit_app.spotify_client import SpotifyClient
+from streamlit_app.tidal_client import TidalClient
+from streamlit_app.playlist import PlaylistManager
+
+bp = Blueprint('routes', __name__)
+
+
+def get_spotify():
+    if 'spotify' not in session:
+        session['spotify'] = SpotifyClient()
+    return session['spotify']
+
+
+def get_tidal():
+    if 'tidal' not in session:
+        session['tidal'] = TidalClient()
+    return session['tidal']
+
+
+def get_playlist():
+    if 'playlist' not in session:
+        session['playlist'] = PlaylistManager()
+    return session['playlist']
+
+
+@bp.route('/')
+def index():
+    sp = get_spotify()
+    td = get_tidal()
+    pl = get_playlist()
+
+    return render_template('index.html',
+                           sp_authenticated=sp.is_authenticated(),
+                           td_authenticated=td.is_authenticated(),
+                           selected_tracks=pl.selected_tracks)
+
+
+@bp.route('/login/spotify')
+def login_spotify():
+    sp = get_spotify()
+    return redirect(sp.login_url())
+
+
+@bp.route('/login/tidal')
+def login_tidal():
+    td = get_tidal()
+    state = str(uuid.uuid4())
+    return redirect(td.login_url(state))
+
+
+@bp.route('/callback/spotify')
+def callback_spotify():
+    code = request.args.get('code')
+    if code:
+        sp = get_spotify()
+        sp.handle_callback(code)
+    return redirect(url_for('routes.index'))
+
+
+@bp.route('/callback/tidal')
+def callback_tidal():
+    code = request.args.get('code')
+    if code:
+        td = get_tidal()
+        td.handle_callback(code)
+    return redirect(url_for('routes.index'))
+
+
+@bp.route('/search')
+def search():
+    query = request.args.get('q', '')
+    sp = get_spotify()
+    pl = get_playlist()
+    results = sp.search_tracks(query)
+    return render_template('_tracks.html', tracks=results, selected=pl.selected_tracks)
+
+
+@bp.route('/toggle', methods=['POST'])
+def toggle():
+    pl = get_playlist()
+    track = {
+        'id': request.form.get('id'),
+        'uri': request.form.get('uri'),
+        'name': request.form.get('name'),
+        'artists': request.form.get('artists', ''),
+    }
+    pl.toggle_track(track)
+    return render_template('_track.html', track=track, selected_tracks=pl.selected_tracks)
+
+
+@bp.route('/create_playlist', methods=['POST'])
+def create_playlist():
+    name = request.form.get('name')
+    service = request.form.get('service', 'spotify')
+    pl = get_playlist()
+    if service == 'spotify':
+        sp = get_spotify()
+        uris = [t['uri'] for t in pl.selected_tracks]
+        playlist = sp.create_playlist(name, uris)
+    else:
+        td = get_tidal()
+        ids = [t['id'] for t in pl.selected_tracks]
+        # Dummy user id for example
+        playlist = td.create_playlist('me', name, ids)
+    pl.selected_tracks = []
+    return redirect(url_for('routes.index'))

--- a/flask_app/templates/_track.html
+++ b/flask_app/templates/_track.html
@@ -1,0 +1,14 @@
+<div class="track" hx-target="this" hx-swap="outerHTML">
+  <span>{{ current['name'] }} - {{ ', '.join(a['name'] for a in current.get('artists', [])) }}</span>
+  <form hx-post="{{ url_for('routes.toggle') }}" hx-target="closest div" hx-swap="outerHTML">
+    <input type="hidden" name="id" value="{{ current['id'] }}">
+    <input type="hidden" name="uri" value="{{ current['uri'] }}">
+    <input type="hidden" name="name" value="{{ current['name'] }}">
+    <input type="hidden" name="artists" value="{{ ', '.join(a['name'] for a in current.get('artists', [])) }}">
+    {% if current['id'] in selected_ids %}
+    <button type="submit">Remove</button>
+    {% else %}
+    <button type="submit">Add</button>
+    {% endif %}
+  </form>
+</div>

--- a/flask_app/templates/_tracks.html
+++ b/flask_app/templates/_tracks.html
@@ -1,0 +1,5 @@
+{% for track in tracks %}
+  {% set selected_ids = [t['id'] for t in selected] %}
+  {% set current = track %}
+  {% include '_track.html' %}
+{% endfor %}

--- a/flask_app/templates/base.html
+++ b/flask_app/templates/base.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Virtual Vinyl</title>
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/flask_app/templates/index.html
+++ b/flask_app/templates/index.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Virtual Vinyl</h1>
+
+{% if not sp_authenticated %}
+  <a href="{{ url_for('routes.login_spotify') }}">Login with Spotify</a>
+{% else %}
+  <input type="text" name="q" placeholder="Search" hx-get="{{ url_for('routes.search') }}" hx-target="#results" hx-trigger="keyup changed delay:500ms">
+  <div id="results"></div>
+  <form method="post" action="{{ url_for('routes.create_playlist') }}">
+    <input type="text" name="name" placeholder="Playlist name">
+    <button type="submit">Create Playlist</button>
+  </form>
+{% endif %}
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,9 @@ spotipy==2.25.1
 requests==2.32.4
 python-dotenv==1.1.1
 dash==3.1.1
+flask==3.0.3
+flask-session==0.8.0
+# The following are frontend libraries referenced by the templates
+# They are optional since they are loaded via CDN
+# htmx
+# alpinejs

--- a/streamlit_app/spotify_client.py
+++ b/streamlit_app/spotify_client.py
@@ -8,10 +8,10 @@ load_dotenv(dotenv_path='.env',
             verbose=True,
             override=False)
 
-SPOTIPY_CLIENT_ID = os.getenv('SPOTIPY_CLIENT_ID')
-logging.warning("SPOTIPY_CLIENT_ID: %s", SPOTIPY_CLIENT_ID)
-SPOTIPY_CLIENT_SECRET = os.getenv('SPOTIPY_CLIENT_SECRET')
-logging.warning("SPOTIPY_CLIENT_SECRET: %s", SPOTIPY_CLIENT_SECRET)
+SPOTIFY_CLIENT_API = os.getenv('SPOTIFY_CLIENT_API')
+logging.warning("SPOTIFY_CLIENT_API: %s", SPOTIFY_CLIENT_API)
+SPOTIFY_SECRET_API = os.getenv('SPOTIFY_SECRET_API')
+logging.warning("SPOTIFY_SECRET_API: %s", SPOTIFY_SECRET_API)
 REDIRECT_URI = os.getenv('REDIRECT_URI')
 logging.warning("REDIRECT_URI: %s", REDIRECT_URI)
 
@@ -19,10 +19,12 @@ class SpotifyClient:
     """Minimal wrapper around spotipy for Virtual Vinyl."""
 
     def __init__(self):
+        if not all([SPOTIFY_CLIENT_API, SPOTIFY_SECRET_API, REDIRECT_URI]):
+            raise Exception("Missing Spotify credentials")
         self.client = None
         self.auth_manager = SpotifyOAuth(
-            client_id=SPOTIPY_CLIENT_ID,
-            client_secret=SPOTIPY_CLIENT_SECRET,
+            client_id=SPOTIFY_CLIENT_API,
+            client_secret=SPOTIFY_SECRET_API,
             redirect_uri=REDIRECT_URI,
             scope='user-read-private user-read-email user-top-read playlist-modify-public playlist-modify-private',
             open_browser=False,


### PR DESCRIPTION
## Summary
- add new Flask `flask_app` package with routes and templates
- support login flows and playlist creation using Spotify/Tidal clients
- integrate HTMX and Alpine.js in templates
- include Flask instructions in README
- fix Spotify client env vars

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687dfa80b7d88328ae11cd5962f1d9f0